### PR TITLE
:sparkles: Implement generic sender for Python

### DIFF
--- a/midi-script/Interface.py
+++ b/midi-script/Interface.py
@@ -85,3 +85,14 @@ class Interface(object):
             def set_fn(ns, value): return setattr(ns, prop, value)
 
         return set_fn(ns, value)
+
+    def __getattr__(self, fnName):
+        def wrapper(ns, *args, **kw):
+            if hasattr(ns, fnName):
+                self.log_message('Generic: %s.%s called with %r %r' %
+                                 (type(self).__name__, fnName, args, kw))
+                return getattr(ns, fnName)(*args, **kw)
+            self.log_message('Generic: Unknown method %s.%s' %
+                             (type(self).__name__, fnName))
+            raise AttributeError(attr)
+        return wrapper

--- a/src/ns/index.ts
+++ b/src/ns/index.ts
@@ -47,7 +47,7 @@ export class Namespace<GP, TP, SP, OP> {
     );
   }
 
-  protected async sendCommand(
+  async sendCommand(
     name: string,
     args?: { [k: string]: any },
     timeout?: number,


### PR DESCRIPTION
Using `__getattr__`, we can catch missing methods in Python and try
to call them on the ns directly.

This will solve #11 -- allowing someone to call `sendCommand('fire')` directly, without `fire` having been defined.