### PR TITLE
fix details in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ get an overview of the current of your set.
 
 To use this library, you'll need to install and activate the MIDI Remote Script
 in Ableton.js. To do that, copy the `midi-script` folder of this repo to
-Ableton's Remote Scripts folder. If you prefer, you can rename it to something
-like `AbletonJS` for better identification. The MIDI Remote Scripts folder is
+Ableton's Remote Scripts folder and rename it to `AbletonJS`. The MIDI Remote Scripts folder is
 usually located at:
 
 - **Windows:** {path to Ableton}\Resources\MIDI\Remote Scripts
@@ -55,8 +54,8 @@ const test = async () => {
   ableton.song.addListener("is_playing", (p) => console.log("Playing:", p));
   ableton.song.addListener("tempo", (t) => console.log("Tempo:", t));
 
-  const cues = await ableton.get("cue_points");
-  console.log(cues.map((c) => c.raw));
+  const tempo = await ableton.song.get("tempo");
+  console.log(tempo);
 };
 
 test();

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,7 +216,7 @@ export class Ableton extends EventEmitter implements ConnectionEventEmitter {
             [
               `The command ${cls}.${name}(${arg}) timed out after ${timeout} ms.`,
               `Please make sure that Ableton is running and that you have the latest`,
-              `version of AbletonJS' midi script installed, listening on port`,
+              `version of AbletonJS' midi script installed and renamed to "AbletonJS", listening on port`,
               `${this.sendPort} and sending on port ${this.listenPort}.`,
             ].join(" "),
             payload,


### PR DESCRIPTION
Hi! Love this project so far. I found the following discrepancies when trying to set up.

First, AbletonJS doesn't seem to work for me unless I rename the midi scripts folder after moving it. As a result, it might just be better for the documentation to tell people to rename the folder.

Additionally, I noticed that the example code didn't work out of the box. I've added `.song` to fix the example code and replaced the example with `tempo` which I feel like is a little bit better as an example just because it will provide a value even with a fresh project.

Let me know if you have any thoughts. Thanks!