### PR TITLE
:wrench: Add GitHub repo to NPM page

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "author": "Leo Bernard <admin@leolabs.org>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leolabs/ableton-js.git"
+  },
   "files": [
     "**/*.js",
     "**/*.d.ts",


### PR DESCRIPTION
When I was on [the NPM page](https://www.npmjs.com/package/ableton-js), it would have been nice to be able to get to the source code directly.