### PR TITLE
:bug: Fix connected status on load of Ableton class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export class Ableton extends EventEmitter implements ConnectionEventEmitter {
   >();
   private eventListeners = new Map<string, Array<(data: any) => any>>();
   private heartbeatInterval: NodeJS.Timeout;
-  private _isConnected = true;
+  private _isConnected = false;
   private cancelConnectionEvent = false;
   private buffer: Buffer[] = [];
   private latency: number = 0;


### PR DESCRIPTION
By default the `.isConnected()` function returns `true` when the library has not initalised yet.

This is because the private variable _isConnected initialises as `true`.

This another effect that we'd expect the heartbeat from the 'connect' event never fires.

### Scenario

Imagine the scenarios with the following code:

```js
import { Ableton } from 'ableton-js';

const ableton = new Ableton();

console.log('Connected: ', ableton.isConnected());
ableton.on('connect', () => console.log('Connected!');
```

| | Ableton is running before running code | Ableton is not running and then starts running |
|-|-|-|
| With this PR | `Connected: false` -> `Connected!` |  `Connected: false` -> `Connected!` | 
| Production |  `Connected: true` |  `Connected: true` -> `Connected!` |

What do you think?

Currently if you use something like this you get an error because Ableton isn't actually available:

```js
if (ableton.isConnected()) {
  await ableton.song.set('tempo', 200);
}
```

The disconnect (and reconnect) events seem to work as expected.


