### PR TITLE
adds support for getting the group_track property from a Track object

### DIFF
--- a/midi-script/Track.py
+++ b/midi-script/Track.py
@@ -25,3 +25,6 @@ class Track(Interface):
 
     def get_clip_slots(self, ns):
         return list(map(ClipSlot.serialize_clip_slot, ns.clip_slots))
+
+    def get_group_track(self, ns):
+        return Track.serialize_track(ns.group_track)


### PR DESCRIPTION
This small PR fixes the get("group_track") method having it return the RawTrack object instead of a string.