### PR TITLE
Forward requested midi cc and note messages

### DIFF
--- a/midi-script/Midi.py
+++ b/midi-script/Midi.py
@@ -1,0 +1,55 @@
+from __future__ import absolute_import
+
+from .Interface import Interface
+
+
+class Midi(Interface):
+    event_id = None
+
+    def __init__(self, c_instance, socket, tracked_midi, update_midi_callback):
+        super(Midi, self).__init__(c_instance, socket)
+        self.outputs = set()
+        self.tracked_midi = tracked_midi
+        self.update_midi = update_midi_callback
+
+    def get_ns(self, nsid):
+        return self
+
+    def set_midi_outputs(self, ns, outputs):
+        self.outputs.clear()
+        for output in outputs:
+            try:
+                midi_type = output.get("type")
+                if midi_type != "cc" and midi_type != "note":
+                    raise ValueError("invalid midi type " + str(midi_type))
+                self.outputs.add((midi_type, output.get("channel"), output.get("target")))
+            except ValueError as e:
+                self.log_message(e)
+            except:
+                self.log_message("invalid midi output requested: " + str(output))
+
+    def remove_midi_listener(self, fn):
+        self.event_id = None
+        self.tracked_midi.clear()
+        self.update_midi()
+
+    def add_listener(self, ns, prop, eventId, nsid="Default"):
+        if prop != "midi":
+            raise Exception("Listener " + str(prop) + " does not exist.")
+
+        if self.event_id is not None:
+            self.log_message("midi listener already exists")
+            return self.event_id
+
+        self.log_message("Attaching midi listener")
+
+        self.tracked_midi.clear()
+        self.tracked_midi.update(self.outputs)
+        self.update_midi()
+        self.event_id = eventId
+
+        return eventId
+
+    def send_midi(self, midi_bytes):
+        if self.event_id is not None:
+            self.socket.send(self.event_id, {"bytes": midi_bytes})

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { unzipSync, deflateSync } from "zlib";
 import { Song } from "./ns/song";
 import { Internal } from "./ns/internal";
 import { Application } from "./ns/application";
+import { Midi } from "./ns/midi";
 import { getPackageVersion } from "./util/package-version";
 
 interface Command {
@@ -65,6 +66,7 @@ export class Ableton extends EventEmitter implements ConnectionEventEmitter {
   public song = new Song(this);
   public application = new Application(this);
   public internal = new Internal(this);
+  public midi = new Midi(this);
 
   constructor(
     private host = "127.0.0.1",

--- a/src/ns/midi.ts
+++ b/src/ns/midi.ts
@@ -1,0 +1,124 @@
+import {Namespace} from "./index";
+import {Ableton} from "../index";
+
+export enum MidiCommand {
+    NoteOn = 128,
+    NoteOff = 144,
+    AfterTouch = 160,
+    ControlChange = 176,
+    PatchChange = 192,
+    ChannelPressure = 208,
+    PitchBend = 224,
+    SysExStart = 240,
+    MidiTimeCodeQuarterFrame = 241,
+    SongPositionPointer = 242,
+    SongSelect = 243,
+    TuneRequest = 246,
+    SysExEnd = 247,
+    TimingClock = 248,
+    Start = 250,
+    Continue = 251,
+    Stop = 252,
+    ActiveSensing = 254,
+    SystemReset = 255,
+}
+
+export interface MidiMapping {
+    type: "cc" | "note";
+    channel: number;
+    target: number;
+}
+
+export interface MidiNote {
+    command: MidiCommand.NoteOn | MidiCommand.NoteOff
+    key: number
+    velocity: number
+}
+
+export interface MidiCC {
+    command: MidiCommand.ControlChange
+    controller: number
+    value: number
+}
+
+export class MidiMessage {
+    command: MidiCommand
+    parameter1: number | null = null
+    parameter2: number | null = null
+
+    constructor(raw: RawMidiMessage) {
+        switch (raw.bytes.length) {
+            case 0:
+                throw "bytes missing from midi message"
+            case 3:
+                this.parameter1 = raw.bytes[1]
+                this.parameter2 = raw.bytes[2]
+                break
+            case 2:
+                this.parameter1 = raw.bytes[1]
+                break
+            case 1:
+                break
+            default:
+                throw "invalid midi message length: " + raw.bytes.length
+        }
+        if (!(raw.bytes[0] in MidiCommand)) {
+            throw "invalid midi command: " + raw.bytes[0]
+        }
+        this.command = raw.bytes[0]
+    }
+
+    toCC(): MidiCC {
+        if (this.command !== MidiCommand.ControlChange) {
+            throw "not a midi CC message"
+        }
+        return {
+            command: this.command,
+            controller: this.parameter1 as number,
+            value: this.parameter2 as number
+        }
+    }
+
+    toNote(): MidiNote {
+        if (this.command !== MidiCommand.NoteOn && this.command !== MidiCommand.NoteOff) {
+            throw "not a midi note message"
+        }
+        return {
+            command: this.command,
+            key: this.parameter1 as number,
+            velocity: this.parameter2 as number
+        }
+    }
+}
+
+export interface RawMidiMessage {
+    bytes: number[]
+}
+
+export interface GettableProperties {
+}
+
+export interface TransformedProperties {
+    midi: MidiMessage,
+}
+
+export interface SettableProperties {
+    midi_outputs: MidiMapping[]
+}
+
+export interface ObservableProperties {
+    midi: RawMidiMessage
+}
+
+export class Midi extends Namespace<GettableProperties,
+    TransformedProperties,
+    SettableProperties,
+    ObservableProperties> {
+    constructor(ableton: Ableton) {
+        super(ableton, "midi");
+
+        this.transformers = {
+            midi: (msg: RawMidiMessage) => new MidiMessage(msg)
+        }
+    }
+}


### PR DESCRIPTION
For: #47 

Allows forwarding of midi message from Ableton.

To register a list of midi notes or control changes to forward:
```Typescript
await ableton.midi.set("midi_outputs", [
    {type: "note", channel: 0, target: 60},
    {type: "cc", channel: 0, target: 25},
])
```

Right now only notes and control changes are mappable.

Then you could add a listener to receive the requested midi messages:
```Typescript
await ableton.midi.addListener("midi", (msg) => {
    switch (msg.command) {
        case MidiCommand.NoteOn:
        case MidiCommand.NoteOff:
            const note = msg.toNote()
            console.log(`midi key: '${note.key}' velocity: '${note.velocity}'`)
            break
        case MidiCommand.ControlChange:
            const cc = msg.toCC()
            console.log(`midi controller: '${cc.controller}' value: '${cc.value}'`)
            break
        default:
            console.log(`unhandled command: '${msg.command}'`)
    }
})
```

As long as the midi signals you are requesting aren't mapped elsewhere in Ableton, the messages should get forwarded.

If you have the midi signals mapped to a control, they will not get sent however.