### PR TITLE
add Track's `duplicate_clip_to_arrangement` method

### DIFF
--- a/midi-script/Track.py
+++ b/midi-script/Track.py
@@ -25,3 +25,6 @@ class Track(Interface):
 
     def get_clip_slots(self, ns):
         return list(map(ClipSlot.serialize_clip_slot, ns.clip_slots))
+
+    def duplicate_clip_to_arrangement(self, ns, clip_id, time):
+        return ns.duplicate_clip_to_arrangement(self.get_obj(clip_id), time)

--- a/src/ns/track.ts
+++ b/src/ns/track.ts
@@ -168,4 +168,11 @@ export class Track extends Namespace<
         clip_slots.map((c) => new ClipSlot(ableton, c)),
     };
   }
+
+  duplicateClipToArrangement(clipID: number, time: number) {
+    return this.sendCommand("duplicate_clip_to_arrangement", {
+      clip_id: clipID,
+      time: time
+    });
+  }
 }


### PR DESCRIPTION
Allows a clip to be copied into a track in arrangement view by its id