### PR TITLE
Fix outdated ID types

### DIFF
--- a/src/ns/song-view.ts
+++ b/src/ns/song-view.ts
@@ -29,8 +29,8 @@ export interface SettableProperties {
   draw_mode: boolean;
   follow_song: boolean;
   highlighted_clip_slot: number;
-  selected_scene: number;
-  selected_track: number;
+  selected_scene: RawScene['id'];
+  selected_track: RawTrack['id'];
 }
 
 export interface ObservableProperties {


### PR DESCRIPTION
Added inferred types for the settable properties. (was number, actually is string, should be the same type as the id of the raw element)