### PR TITLE
Update README to have correct start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ After starting Ableton Live, add the script to your list of control surfaces:
 ![Ableton Live Settings](https://i.imgur.com/a34zJca.png)
 
 If you've forked this project on macOS, you can also use yarn to do that for
-you. Running `yarn ableton:start` will copy the `midi-script` folder, open
-Ableton and show a stream of log messages until you kill it.
+you. Running `yarn ableton10:start` or `yarn ableton11:start` (depending on your
+app version) will copy the `midi-script` folder, open Ableton and show a stream
+of log messages until you kill it.
 
 ## Using Ableton.js
 


### PR DESCRIPTION
When setting up my Ableton JS control surface, I noticed the README recommends utilizing `yarn ableton:start` to configure the remote script, but the `package.json` only has the scripts `yarn ableton10:start` and `yarn ableton11:start`.  I updated the README procedures to reflect this.