### PR TITLE
Add new functions and fix bugs

### DIFF
--- a/midi-script/Track.py
+++ b/midi-script/Track.py
@@ -78,4 +78,8 @@ class Track(Interface):
         return MixerDevice.serialize_mixer_device(ns.mixer_device)
 
     def duplicate_clip_to_arrangement(self, ns, clip_id, time):
-        return ns.duplicate_clip_to_arrangement(self.get_obj(clip_id), time)
+        clip = ns.duplicate_clip_to_arrangement(self.get_obj(clip_id), time)
+        return Clip.serialize_clip(clip)
+
+    def delete_clip(self, ns, clip_id):
+        return ns.delete_clip(self.get_obj(clip_id))

--- a/src/ns/clip.ts
+++ b/src/ns/clip.ts
@@ -327,16 +327,16 @@ export class Clip extends Namespace<
    * Deletes all notes that start in the given area.
    */
   removeNotesExtended(
-    fromTime: number,
     fromPitch: number,
-    timeSpan: number,
     pitchSpan: number,
+    fromTime: number,
+    timeSpan: number,
   ) {
     return this.sendCommand("remove_notes_extended", [
-      fromTime,
       fromPitch,
-      timeSpan,
       pitchSpan,
+      fromTime,
+      timeSpan,
     ]);
   }
 

--- a/src/ns/track.ts
+++ b/src/ns/track.ts
@@ -224,4 +224,29 @@ export class Track extends Namespace<
       time: time,
     });
   }
+
+  /**
+   * Deletes the given clip from the arrangement of this track.
+   * Raises a runtime error when the clip belongs to another track
+   */
+  deleteClip(clipOrId: Clip | string) {
+    return this.sendCommand("delete_clip", {
+      clip_id: typeof clipOrId === "string" ? clipOrId : clipOrId.raw.id,
+    });
+  }
+
+  /**
+   * Delete a device identified by the index in the 'devices' list of current track
+   */
+  deleteDevice(index: number) {
+    return this.sendCommand("delete_device", [index]);
+  }
+
+  /**
+   * Given an absolute path to a valid audio file in a supported format, creates an audio clip that references the file in the clip slot.
+   * Throws an error if the clip slot doesn't belong to an audio track or if the track is frozen.
+   */
+  createAudioClip(filePath: string, position: number) {
+    return this.sendCommand("create_audio_clip", [filePath, position]);
+  }
 }


### PR DESCRIPTION
- Fix unusable function bug by adjusting the parameter order of removeNotesExtended in src/ns/clip.ts
- Add delete_clip method in midi-script/Track.py to delete a specified clip
- Add deleteClip , deleteDevice , and createAudioClip methods in src/ns/track.ts to extend track functionality
- Fix bug where the return value of duplicate_clip_to_arrangement could not be correctly retrieved in ableton-js