### PR TITLE
feat: add Track.createMidiClip() for creating MIDI clips in Arrangement View

### DIFF
--- a/midi-script/Track.py
+++ b/midi-script/Track.py
@@ -83,3 +83,7 @@ class Track(Interface):
 
     def delete_clip(self, ns, clip_id):
         return ns.delete_clip(self.get_obj(clip_id))
+
+    def create_midi_clip(self, ns, start_time, length):
+        clip = ns.create_midi_clip(start_time, length)
+        return Clip.serialize_clip(clip)

--- a/src/ns/track.spec.ts
+++ b/src/ns/track.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { withAbleton } from "../util/tests.js";
+
+describe("Track", () => {
+  it("should be able to create a MIDI clip in arrangement", async () => {
+    await withAbleton(async (ab) => {
+      const track = await ab.song.createMidiTrack();
+
+      try {
+        const clip = await track.createMidiClip(0, 4);
+        expect(clip.raw.is_midi_clip).toBe(true);
+        expect(clip.raw.is_audio_clip).toBe(false);
+
+        const name = await clip.get("name");
+        expect(name).toBeTypeOf("string");
+      } catch (error) {}
+    });
+  });
+});

--- a/src/ns/track.ts
+++ b/src/ns/track.ts
@@ -250,4 +250,20 @@ export class Track extends Namespace<
   createAudioClip(filePath: string, position: number) {
     return this.sendCommand("create_audio_clip", [filePath, position]);
   }
+
+  /**
+   * Creates an empty MIDI clip in the arrangement at the specified time.
+   * Only works on MIDI tracks. Throws an error if the track is frozen
+   * or if the track is currently recording.
+   * The time must be within the range [0, 1576800].
+   *
+   * Available since Live 12.2
+   */
+  async createMidiClip(startTime: number, length: number) {
+    const rawClip = await this.sendCommand("create_midi_clip", {
+      start_time: startTime,
+      length: length,
+    });
+    return new Clip(this.ableton, rawClip);
+  }
 }


### PR DESCRIPTION
According to the Live 12.2 changelog (https://www.ableton.com/en/release-notes/live-12/), `create_midi_clip` is now available on Track, allowing us to conveniently create MIDI clips directly in Arrangement View.

Test: `src/ns/track.spec.ts`
