### PR TITLE
fix: register missing Chain/DrumPad namespace

### DIFF
--- a/midi-script/AbletonJS.py
+++ b/midi-script/AbletonJS.py
@@ -11,9 +11,11 @@ from .Session import Session
 from .ApplicationView import ApplicationView
 from .Browser import Browser
 from .BrowserItem import BrowserItem
+from .Chain import Chain
 from .CuePoint import CuePoint
 from .Device import Device
 from .DeviceParameter import DeviceParameter
+from .DrumPad import DrumPad
 from .MixerDevice import MixerDevice
 from .Scene import Scene
 from .Song import Song
@@ -47,9 +49,11 @@ class AbletonJS(ControlSurface):
             "session": Session(c_instance, self.socket, self),
             "browser": Browser(c_instance, self.socket, self.application()),
             "browser-item": BrowserItem(c_instance, self.socket),
+            "chain": Chain(c_instance, self.socket),
             "cue-point": CuePoint(c_instance, self.socket),
             "device": Device(c_instance, self.socket),
             "device-parameter": DeviceParameter(c_instance, self.socket),
+            "drum-pad": DrumPad(c_instance, self.socket),
             "internal": Internal(c_instance, self.socket),
             "midi": Midi(c_instance, self.socket, self.tracked_midi, self.request_rebuild_midi_map),
             "mixer-device": MixerDevice(c_instance, self.socket),

--- a/midi-script/Chain.py
+++ b/midi-script/Chain.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+
+from .Interface import Interface
+
+
+class Chain(Interface):
+    @staticmethod
+    def serialize_chain(chain):
+        if chain is None:
+            return None
+
+        chain_id = Interface.save_obj(chain)
+
+        mute = False
+        solo = False
+        color = None
+
+        try:
+            mute = chain.mute
+        except:
+            pass
+
+        try:
+            solo = chain.solo
+        except:
+            pass
+
+        try:
+            color = chain.color
+        except:
+            pass
+
+        return {
+            "id": chain_id,
+            "name": chain.name,
+            "color": color,
+            "mute": mute,
+            "solo": solo,
+        }
+
+    def __init__(self, c_instance, socket):
+        super(Chain, self).__init__(c_instance, socket)
+
+    def get_devices(self, ns):
+        from .Device import Device
+        return map(Device.serialize_device, ns.devices)
+
+    def get_mixer_device(self, ns):
+        from .MixerDevice import MixerDevice
+        return MixerDevice.serialize_mixer_device(ns.mixer_device)

--- a/midi-script/Device.py
+++ b/midi-script/Device.py
@@ -25,3 +25,24 @@ class Device(Interface):
 
     def get_type(self, ns):
         return str(ns.type)
+
+    def get_chains(self, ns):
+        from .Chain import Chain
+        try:
+            return map(Chain.serialize_chain, ns.chains)
+        except AttributeError:
+            return []
+
+    def get_return_chain(self, ns):
+        from .Chain import Chain
+        try:
+            return Chain.serialize_chain(ns.return_chain)
+        except AttributeError:
+            return None
+
+    def get_drum_pads(self, ns):
+        from .DrumPad import DrumPad
+        try:
+            return map(DrumPad.serialize_drum_pad, ns.drum_pads)
+        except AttributeError:
+            return []

--- a/midi-script/DrumPad.py
+++ b/midi-script/DrumPad.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+from .Interface import Interface
+
+
+class DrumPad(Interface):
+    @staticmethod
+    def serialize_drum_pad(pad):
+        if pad is None:
+            return None
+
+        pad_id = Interface.save_obj(pad)
+
+        mute = False
+        solo = False
+        note = None
+
+        try:
+            mute = pad.mute
+        except:
+            pass
+
+        try:
+            solo = pad.solo
+        except:
+            pass
+
+        try:
+            note = pad.note
+        except:
+            pass
+
+        return {
+            "id": pad_id,
+            "name": pad.name,
+            "note": note,
+            "mute": mute,
+            "solo": solo,
+        }
+
+    def __init__(self, c_instance, socket):
+        super(DrumPad, self).__init__(c_instance, socket)
+
+    def get_chains(self, ns):
+        from .Chain import Chain
+        return map(Chain.serialize_chain, ns.chains)

--- a/src/ns/chain.ts
+++ b/src/ns/chain.ts
@@ -1,0 +1,66 @@
+import { Ableton } from "../index.js";
+import { Namespace } from "./index.js";
+import { Device, RawDevice } from "./device.js";
+import { MixerDevice, RawMixerDevice } from "./mixer-device.js";
+
+export interface GettableProperties {
+  color: number | null;
+  devices: RawDevice[];
+  mixer_device: RawMixerDevice;
+  mute: boolean;
+  name: string;
+  solo: boolean;
+}
+
+export interface TransformedProperties {
+  devices: Device[];
+  mixer_device: MixerDevice;
+}
+
+export interface SettableProperties {
+  mute: boolean;
+  solo: boolean;
+}
+
+export interface ObservableProperties {
+  mute: boolean;
+  name: string;
+  solo: boolean;
+}
+
+export interface RawChain {
+  readonly id: string;
+  readonly name: string;
+  readonly color: number | null;
+  readonly mute: boolean;
+  readonly solo: boolean;
+}
+
+/**
+ * Represents a device chain inside a rack device (Instrument/Audio Effect/MIDI
+ * Effect Rack), or the chain owned by a single Drum Rack pad. Not every device
+ * has chains - check `Device.can_have_chains`/`can_have_drum_pads` first.
+ */
+export class Chain extends Namespace<
+  GettableProperties,
+  TransformedProperties,
+  SettableProperties,
+  ObservableProperties
+> {
+  constructor(
+    ableton: Ableton,
+    public raw: RawChain,
+  ) {
+    super(ableton, "chain", raw.id);
+
+    this.transformers = {
+      devices: (devices) => devices.map((d) => new Device(ableton, d)),
+      mixer_device: (m) => new MixerDevice(ableton, m),
+    };
+
+    this.cachedProps = {
+      devices: true,
+      mixer_device: true,
+    };
+  }
+}

--- a/src/ns/device.ts
+++ b/src/ns/device.ts
@@ -1,20 +1,28 @@
 import { Ableton } from "../index.js";
 import { Namespace } from "./index.js";
 import { RawDeviceParameter, DeviceParameter } from "./device-parameter.js";
+import { Chain, RawChain } from "./chain.js";
+import { DrumPad, RawDrumPad } from "./drum-pad.js";
 
 export interface GettableProperties {
   can_have_chains: boolean;
   can_have_drum_pads: boolean;
+  chains: RawChain[];
   class_display_name: string;
   class_name: string;
+  drum_pads: RawDrumPad[];
   is_active: boolean;
   name: string;
   parameters: RawDeviceParameter[];
+  return_chain: RawChain | null;
   type: DeviceType;
 }
 
 export interface TransformedProperties {
+  chains: Chain[];
+  drum_pads: DrumPad[];
   parameters: DeviceParameter[];
+  return_chain: Chain | null;
 }
 
 export interface SettableProperties {
@@ -54,11 +62,17 @@ export class Device extends Namespace<
     super(ableton, "device", raw.id);
 
     this.transformers = {
+      chains: (chains) => chains.map((c) => new Chain(ableton, c)),
+      drum_pads: (pads) => pads.map((p) => new DrumPad(ableton, p)),
       parameters: (ps) => ps.map((p) => new DeviceParameter(ableton, p)),
+      return_chain: (c) => (c ? new Chain(ableton, c) : null),
     };
 
     this.cachedProps = {
+      chains: true,
+      drum_pads: true,
       parameters: true,
+      return_chain: true,
     };
   }
 }

--- a/src/ns/drum-pad.ts
+++ b/src/ns/drum-pad.ts
@@ -1,0 +1,60 @@
+import { Ableton } from "../index.js";
+import { Namespace } from "./index.js";
+import { Chain, RawChain } from "./chain.js";
+
+export interface GettableProperties {
+  chains: RawChain[];
+  mute: boolean;
+  name: string;
+  note: number | null;
+  solo: boolean;
+}
+
+export interface TransformedProperties {
+  chains: Chain[];
+}
+
+export interface SettableProperties {
+  mute: boolean;
+  solo: boolean;
+}
+
+export interface ObservableProperties {
+  mute: boolean;
+  name: string;
+  solo: boolean;
+}
+
+export interface RawDrumPad {
+  readonly id: string;
+  readonly name: string;
+  readonly note: number | null;
+  readonly mute: boolean;
+  readonly solo: boolean;
+}
+
+/**
+ * Represents a single pad of a Drum Rack device. Reach a pad's own device
+ * chain (e.g. its Simpler) via `chains` - a pad usually has 0 or 1 chains.
+ */
+export class DrumPad extends Namespace<
+  GettableProperties,
+  TransformedProperties,
+  SettableProperties,
+  ObservableProperties
+> {
+  constructor(
+    ableton: Ableton,
+    public raw: RawDrumPad,
+  ) {
+    super(ableton, "drum-pad", raw.id);
+
+    this.transformers = {
+      chains: (chains) => chains.map((c) => new Chain(ableton, c)),
+    };
+
+    this.cachedProps = {
+      chains: true,
+    };
+  }
+}


### PR DESCRIPTION
`Device.chains` / `Device.return_chain` / `Device.drum_pads` (and `DrumPad.chains`) were never reachable through the JS API: the Python Remote Script never registered chain/drum-pad handlers in `AbletonJS.py`, even though nothing downstream could have worked without them. Any attempt to read a rack device's chains failed with `"No handler for namespace chain"`.

Adds `Chain` and `DrumPad` as full namespace classes at both layers:

- `midi-script/Chain.py`, `midi-script/DrumPad.py`: new `Interface` subclasses mirroring the existing Track/Device serialization pattern, registered in `AbletonJS.py`'s handler dict. `Device.py` gains `get_chains`/`get_return_chain`/`get_drum_pads`, each guarded by `try/except AttributeError` since only rack-type devices expose these on Live's object model.
- `src/ns/chain.ts`, `src/ns/drum-pad.ts`: new `Namespace` subclasses with full Gettable/Transformed/Settable/Observable property typing, following the existing Scene/Track pattern.
- `src/ns/device.ts`: wires `chains`/`return_chain`/`drum_pads` into `Device`'s `GettableProperties`/`TransformedProperties`.

This unblocks per-pad Drum Rack editing (note/mute/solo per pad, and reaching a pad's own device chain to tune e.g. its Simpler) and rack-chain traversal in general — useful for anything building on top of Instrument, Audio Effect, or MIDI Effect Racks, not just one specific use case.

Note: `SongView.selected_chain` is still typed `any` with a `"Todo: Implement Chain class"` comment — now that `Chain` exists, that's a natural follow-up, left out of this PR to keep it scoped to what's been verified.

**Live-tested:** loaded a real Drum Rack, confirmed `get_device_properties({drum_pads: true})` returns all 128 pads; loaded a populated stock kit and confirmed a pad's `chains` (with nested `devices`) resolves correctly end to end (track → rack device → drum pad → chain → device).
