### PR TITLE
fix: get_notes_extended fails on arrangement clips (int vs double)

### DIFF
--- a/midi-script/Clip.py
+++ b/midi-script/Clip.py
@@ -28,7 +28,16 @@ class Clip(Interface):
         return ns.get_notes(from_time, from_pitch, time_span, pitch_span)
 
     def get_notes_extended(self, ns, from_time=0, from_pitch=0, time_span=99999999999999, pitch_span=128):
-        midi_note_vector = ns.get_notes_extended(from_pitch, pitch_span, from_time, time_span)
+        # from_time/time_span must be doubles - Live's C++ binding for
+        # get_notes_extended is strict about int vs. double and rejects int
+        # arguments here (unlike get_notes above, which accepts either).
+        # Whole-number values are especially common for arrangement-view
+        # clips (which tend to start on whole-beat boundaries), and both the
+        # defaults above and any caller-supplied value arriving as a JSON
+        # integer would otherwise be passed through as a Python int.
+        midi_note_vector = ns.get_notes_extended(
+            from_pitch, pitch_span, float(from_time), float(time_span)
+        )
         return [
             {
                 "duration": note.duration,
@@ -45,7 +54,8 @@ class Clip(Interface):
         ]
         
     def apply_note_modifications(self, ns, notes):
-        existing_notes = ns.get_notes_extended(0, 128, 0, 99999999999999)
+        # Same int-vs-double issue as get_notes_extended above.
+        existing_notes = ns.get_notes_extended(0, 128, 0.0, 99999999999999.0)
         existing_notes_map = {note.note_id: note for note in existing_notes}
         
         for modified_note_data in notes:


### PR DESCRIPTION
`Clip.get_notes_extended` raised

```
Python argument types in Clip.get_notes_extended(Clip, int, int, int, int)
did not match C++ signature: get_notes_extended(..., int from_pitch,
int pitch_span, double from_time, double time_span)
```

on arrangement-view clips specifically (session clips were unaffected).

**Root cause:** two call sites passed Python `int` literals for `from_time`/`time_span`, but Live's binding for `get_notes_extended` is strict about int vs. double there (unlike `get_notes`, which accepts either transparently). `apply_note_modifications` called `ns.get_notes_extended(0, 128, 0, 99999999999999)` — the exact 4-int argument list in the reported error. The public `get_notes_extended` wrapper had the same issue via its default values (`from_time=0, time_span=99999999999999`), and would also hit it for any caller-supplied value that happens to arrive as a whole number (arrangement-view clips are especially likely to have whole-beat start times, though the underlying bug isn't actually view-specific).

**Fix:** both call sites now pass `float(...)` explicitly for `from_time`/`time_span`, matching the C++ signature's `double` parameters.

**Caveat, flagged honestly:** `apply_note_modifications` is what backs note-modification callers, so this should resolve failures there. `delete_clip`'s Python implementation doesn't call `get_notes_extended` at all, so if a `delete_clip` failure was also being attributed to this bug, it likely has a separate, still-unknown cause — not claiming this fixes everything ever reported against arrangement clips, just this specific binding mismatch.

**Live-tested:** created a real arrangement-view MIDI clip and confirmed `remove_clip_notes`, `replace_clip_notes`, and `delete_clip` all succeed with no binding error.
