### PR TITLE
fix: CuePoint.SettableProperties missing name

### DIFF
--- a/src/ns/cue-point.ts
+++ b/src/ns/cue-point.ts
@@ -8,7 +8,9 @@ export interface GettableProperties {
 
 export interface TransformedProperties {}
 
-export interface SettableProperties {}
+export interface SettableProperties {
+  name: string;
+}
 
 export interface ObservableProperties {
   name: string;


### PR DESCRIPTION
`CuePoint.GettableProperties` already listed `name`, and Live's object model supports renaming a cue point, but `SettableProperties` was empty — so `cuePoint.set('name', ...)` had no type-safe way to be called even though the underlying generic `Interface.handle()` dispatch would have accepted it at runtime. Adds `name: string` to `SettableProperties` to match.

Small, self-contained fix found while building cue-point tooling on top of `ableton-js` — no behavior change to existing functionality, just closes a gap between what Live/the runtime dispatch already supports and what the TS types allow.

**Live-tested:** created a cue point with a custom name via `set('name', ...)`, confirmed it read back correctly.
